### PR TITLE
<meta/> tag must be self-closing for well-formed XHTML.

### DIFF
--- a/html/layout.html
+++ b/html/layout.html
@@ -2,7 +2,7 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>{{ title }}</title>
   </head>
   <body data-type="book">


### PR DESCRIPTION
<meta/> tag must be self-closing for well-formed XHTML.
