### PR TITLE
Stripping out extraneous semicolons.

### DIFF
--- a/epub/epub.css
+++ b/epub/epub.css
@@ -358,7 +358,7 @@ dd { /* definition list descriptions */
   text-indent: 0;
   margin-left: 20px;
   margin-bottom: 20px;
-  margin-top: -5px;;
+  margin-top: -5px;
 }
 
 dd p {

--- a/mobi/mobi.css
+++ b/mobi/mobi.css
@@ -359,7 +359,7 @@ dd { /* definition list descriptions */
   text-indent: 0;
   margin-left: 20px;
   margin-bottom: 20px;
-  margin-top: -5px;;
+  margin-top: -5px;
 }
 
 dd p {


### PR DESCRIPTION
Removing extraneous semicolons in margin-top rules for `dd`s. 
