### PR TITLE
Fallback to ArialUnicode for rich glyph support.

### DIFF
--- a/pdf/pdf.css
+++ b/pdf/pdf.css
@@ -41,14 +41,14 @@ body[data-type="book"] > figure[data-type="cover"] + section {
   margin-left: 1.625in;
   margin-right: 1in;
   @bottom-left-corner {
-    font-family: SourceSansPro, sans-serif;
+    font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
     font-size: 9pt;
     text-align: left;
     margin-left: 0.375in;
     margin-top: 5pt;
   }
   @top-left {
-    font-family: SourceSansPro, sans-serif;
+    font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
     font-size: 8pt;
     text-align: left;
     margin-left: -0.65in;
@@ -61,14 +61,14 @@ body[data-type="book"] > figure[data-type="cover"] + section {
   margin-right: 1.625in;
   margin-left: 1in;
   @bottom-right-corner {
-    font-family: SourceSansPro, sans-serif;
+    font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
     font-size: 9pt;
     text-align: right;
     margin-top: 5pt;
     margin-right: 0.375in;
   }
   @top-right {
-    font-family: SourceSansPro, sans-serif;
+    font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
     font-size: 8pt;
     text-align: right;
     margin-right: -0.65in;
@@ -167,7 +167,7 @@ section[data-type="titlepage"] {
 
 section[data-type="halftitlepage"] h1, 
 section[data-type="titlepage"] h1 {
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   border-bottom: 0.5pt solid cmyk(0%,0%,0%,100%);
   margin-top: 126pt;
   padding-bottom: 7pt;
@@ -176,7 +176,7 @@ section[data-type="titlepage"] h1 {
 
 section[data-type="halftitlepage"] h2, 
 section[data-type="titlepage"] h2 {
-  font-family: SourceSansPro-Semibold; 
+  font-family: SourceSansPro-Semibold, ArialUnicodeMS; 
   font-size: 13pt;
   text-align: left;
 }
@@ -197,7 +197,7 @@ section[data-type="titlepage"] h1 {
 /* styling and positioning for author names */
 
 section[data-type="titlepage"] p[data-type="author"] {
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-size: 11pt;
   margin-top: 66pt;
 }
@@ -210,7 +210,7 @@ section[data-type="copyright-page"] {
 }
 
 section[data-type="copyright-page"] h1 {
-  font-family: 'SourceSansPro', sans-serif;
+  font-family: 'SourceSansPro', sans-serif, ArialUnicodeMS;
   font-weight: bold;
   font-size: 8pt;
   margin: 0;
@@ -229,7 +229,7 @@ section[data-type="copyright-page"] p.isbn {
 /* dedication */
 
 section[data-type="dedication"] {
-  font-family: 'Crimson-Italic', serif;
+  font-family: 'Crimson-Italic', serif, ArialUnicodeMS;
   font-style: italic;
   page: blank;
   page-break-after: always;
@@ -241,7 +241,7 @@ section[data-type="dedication"] {
 
 section[data-type="dedication"].praise h2.title {
   display: block;
-  font-family: "MyriadPro-SemiboldCond";
+  font-family: "MyriadPro-SemiboldCond", ArialUnicodeMS;
   font-weight: 600;
   font-size: 20pt;
   text-align: center;
@@ -337,7 +337,7 @@ section[data-type="dedication"].praise blockquote p span.emphasis em {
 }
 
 nav[data-type="toc"] > h1 { /* table of contents heading */
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-size: 16pt;
   line-height: 22pt;
   margin-top: 87pt;
@@ -373,7 +373,7 @@ nav[data-type="toc"] li[data-type="appendix"],
 nav[data-type="toc"] li[data-type="glossary"],
 nav[data-type="toc"] li[data-type="index"]
 /*nav[data-type="toc"] ul li.preface.afterword*/ {
-  font-family: SourceSansPro-Semibold, sans-serif;
+  font-family: SourceSansPro-Semibold, sans-serif, ArialUnicodeMS;
   font-size: 9.5pt;
   font-weight: 600;
   margin-top: 14.4pt;
@@ -383,7 +383,7 @@ nav[data-type="toc"] li[data-type="index"]
 
 nav[data-type="toc"] li[data-type="preface"],
 nav[data-type="toc"] li[data-type="foreword"] {
-  font-family: SourceSansPro-Semibold, sans-serif;
+  font-family: SourceSansPro-Semibold, sans-serif, ArialUnicodeMS;
   font-style: italic;
   font-size: 9.5pt;
   font-weight: 600;
@@ -430,7 +430,7 @@ nav[data-type="toc"] li[data-type="chapter"]:before {
 }
 
 li[data-type="sect1"], li[data-type="sect2"] {
-  font-family: SourceSansPro, sans-serif;
+  font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
   font-size: 9.5pt;
   font-weight: normal;
   page-break-after: auto;
@@ -479,7 +479,7 @@ section[data-type="index"] > h1,
 section[data-type="glossary"] > h1,
 section[data-type="colophon"] h1, 
 section.abouttheauthor h1  {
-  font-family: 'Merriweather', serif;
+  font-family: 'Merriweather', serif, ArialUnicodeMS;
   line-height: 22pt;
   margin-bottom: 0.9in;
   margin-top: 0.5in;
@@ -508,7 +508,7 @@ section[data-type="appendix"] > h1 {
 section[data-type="chapter"] > h1:after, 
 section[data-type="appendix"] > h1:after {
   font-size: 65pt;
-  font-family: 'SourceSansPro-ExtraLight', sans-serif;
+  font-family: 'SourceSansPro-ExtraLight', sans-serif, ArialUnicodeMS;
   letter-spacing: -3pt;
   display: block;
   position: relative;
@@ -535,7 +535,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 section[data-type="sect1"] > h1 { /* A-level headings */
-  font-family: 'Merriweather', serif;
+  font-family: 'Merriweather', serif, ArialUnicodeMS;
   font-weight: bold;
   font-size: 12pt;
   line-height: 16pt;
@@ -545,7 +545,7 @@ section[data-type="sect1"] > h1 { /* A-level headings */
 }
 
 section[data-type="sect2"] > h2 { /* B-level headings */
-  font-family: SourceSansPro, sans-serif;
+  font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
   font-weight: bold;
   font-size: 11pt;
   line-height: 12pt;
@@ -554,7 +554,7 @@ section[data-type="sect2"] > h2 { /* B-level headings */
 }
 
 section[data-type="sect3"] > h3 { /* C-level headings */
-  font-family: SourceSansPro-Semibold, sans-serif;
+  font-family: SourceSansPro-Semibold, sans-serif, ArialUnicodeMS;
   font-size: 9.5pt;
   margin-top: 14pt;
   margin-bottom: 10pt;
@@ -687,7 +687,7 @@ div[data-type="part"] {
 }
 
 div[data-type="part"] > h1 {
-  font-family: 'OpenSans-CondBold', sans-serif;
+  font-family: 'OpenSans-CondBold', sans-serif, ArialUnicodeMS;
   font-size: 18pt;
   line-height: 22pt;
   text-align: center;
@@ -697,7 +697,7 @@ div[data-type="part"] > h1 {
 }
 
 div[data-type="part"] > h1:before {
-  font-family: 'OpenSans-Semibold', sans-serif;
+  font-family: 'OpenSans-Semibold', sans-serif, ArialUnicodeMS;
   font-size: 11pt;
   text-transform: uppercase;
   content: "Part " counter(PartNumber);
@@ -801,7 +801,7 @@ ul, ol { /* bulleted and numbered lists */
 }
 
 ul li, ol li {
-  font-family: SourceSansPro, ArialUnicode;
+  font-family: SourceSansPro, ArialUnicodeMS;
   font-size: 9.5pt;
   margin-top: 3pt;
 }
@@ -811,7 +811,7 @@ dl { /* definition lists */
 }
 
 dt { /* definition list terms */
-  font-family: SourceSansPro-Semibold;
+  font-family: SourceSansPro-Semibold, ArialUnicodeMS;
   font-size: 9.5pt;
   line-height: 14pt;
   margin-top: 7pt;
@@ -844,7 +844,7 @@ table caption {
   margin-bottom: 5pt;
   page-break-after: avoid;
   text-align: left;
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-style: italic;
   font-size: 7.5pt;
   line-height: 10pt;
@@ -852,7 +852,7 @@ table caption {
 }
 
 table caption:before {
-  font-family: SourceSansPro-Black, sans-serif;
+  font-family: SourceSansPro-Black, sans-serif, ArialUnicodeMS;
   font-style: normal;
   font-size: 8.5pt;
   counter-increment: TableNumber;
@@ -878,7 +878,7 @@ tr {
 }
 
 th { /* table heading rows */
-  font-family: SourceSansPro, sans-serif;
+  font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
   font-weight: bold;
   font-size: 9pt;
   text-align: left;
@@ -892,7 +892,7 @@ th, td {
 }
 
 td, table p { /* table body text */
-  font-family: SourceSansPro, sans-serif;
+  font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
   font-size: 9pt;
   line-height: 10pt;
 }
@@ -929,7 +929,7 @@ figure figcaption {
   margin-right: -1.25in;
   width: 1in;
   text-align: left;
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-style: italic;
   font-size: 7.5pt;
   line-height: 10pt;
@@ -937,7 +937,7 @@ figure figcaption {
 }
 
 figcaption:before {
-  font-family: SourceSansPro-Black, sans-serif;
+  font-family: SourceSansPro-Black, sans-serif, ArialUnicodeMS;
   font-style: normal;
   font-size: 8.5pt;
   counter-increment: FigureNumber;
@@ -986,7 +986,7 @@ aside[data-type="sidebar"] { /* sidebar containers */
 }
 
 aside h5 { /* sidebar titles */
-  font-family: SourceSansPro-Bold, sans-serif;
+  font-family: SourceSansPro-Bold, sans-serif, ArialUnicodeMS;
   font-size: 11pt;
   line-height: 13pt;
   text-align: center;
@@ -1000,7 +1000,7 @@ aside h6 { /* sidebar subtitles */
 
 aside p, aside dd { /* sidebar text */
   font-size: 7.5pt;
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   line-height: 11.5pt;
   text-indent: 0;
   margin-bottom: 6pt;
@@ -1008,7 +1008,7 @@ aside p, aside dd { /* sidebar text */
 
 aside dt {
   font-size: 7.5pt;
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-weight: bold;
 }
   
@@ -1032,7 +1032,7 @@ div[data-type="warning"] p,
 div[data-type="tip"] p,
 div[data-type="caution"] p,
 div[data-type="important"] p { /* admon text */
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   text-align: left;
   text-indent: 0;
   font-size: 7.5pt;
@@ -1045,7 +1045,7 @@ div[data-type="warning"] li,
 div[data-type="tip"] li,
 div[data-type="caution"] li,
 div[data-type="important"] li {
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-size: 7.5pt;
 }
 
@@ -1054,7 +1054,7 @@ div[data-type="warning"] h1,
 div[data-type="tip"] h1,
 div[data-type="caution"] h1,
 div[data-type="important"] h1 { /* admonition titles */
-  font-family: 'SourceSansPro-Black', sans-serif;
+  font-family: 'SourceSansPro-Black', sans-serif, ArialUnicodeMS;
   font-size: 8.5pt;
   text-transform: uppercase;
   letter-spacing: 0.75pt;
@@ -1074,7 +1074,7 @@ div[data-type="important"] pre {
 /* code */
 
 pre, code { /* monospace font for both code blocks and inline code */
-  font-family: 'UbuntuMono', monospace;
+  font-family: 'UbuntuMono', monospace, ArialUnicodeMS;
 }
 
 pre { /* code blocks */
@@ -1092,7 +1092,7 @@ div[data-type="example"] h5 {
   margin-bottom: 5pt;
   page-break-after: avoid;
   text-align: left;
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-style: italic;
   font-size: 7.5pt;
   line-height: 10pt;
@@ -1100,7 +1100,7 @@ div[data-type="example"] h5 {
 }
 
 div[data-type="example"] h5:before {
-  font-family: 'SourceSansPro-Black', sans-serif;
+  font-family: 'SourceSansPro-Black', sans-serif, ArialUnicodeMS;
   font-style: normal;
   font-size: 8.5pt;
   counter-increment: ExampleNumber;
@@ -1132,7 +1132,7 @@ blockquote {
 
 blockquote p {
   text-indent: 0;
-  font-family: 'SourceSansPro', sans-serif;
+  font-family: 'SourceSansPro', sans-serif, ArialUnicodeMS;
   font-size: 7.5pt;
 }
 
@@ -1162,7 +1162,7 @@ div[data-type="equation"] h5 {
   width: 1in;
   page-break-inside: avoid;
   text-align: left;
-  font-family: Merriweather, serif;
+  font-family: Merriweather, serif, ArialUnicodeMS;
   font-style: italic;
   font-size: 7.5pt;
   line-height: 10pt;
@@ -1170,7 +1170,7 @@ div[data-type="equation"] h5 {
 }
 
 div[data-type="equation"] h5:before {
-  font-family: SourceSansPro-Black, sans-serif;
+  font-family: SourceSansPro-Black, sans-serif, ArialUnicodeMS;
   font-style: normal;
   font-size: 8.5pt;
   counter-increment: EquationNumber;
@@ -1200,7 +1200,7 @@ section[data-type="index"] { page: index }
 @page index:left {
   @bottom-left {
     content: counter(page);
-    font-family: SourceSansPro, sans-serif;
+    font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
   }
   @top-left-corner {
     border-left: solid 20.4pt cmyk(0%,0%,0%,65%);
@@ -1219,7 +1219,7 @@ section[data-type="index"] { page: index }
 @page index:right {
   @bottom-right {
     content: counter(page);
-    font-family: SourceSansPro, sans-serif;
+    font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
   }
   @top-right-corner {
     border-right: solid 20.4pt cmyk(0%,0%,0%,65%);
@@ -1289,7 +1289,7 @@ section[data-type="glossary"] { page: glossary }
   
 @page glossary:left {
   @bottom-left { content: counter(page);
-      font-family: SourceSansPro, sans-serif;
+      font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
  }
   @top-left {
     content: string(term, first);
@@ -1299,7 +1299,7 @@ section[data-type="glossary"] { page: glossary }
 
 @page glossary:right {
   @bottom-right { content: counter(page);
-      font-family: SourceSansPro, sans-serif;
+      font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
  }
   @top-right {
     content: string(term, last);
@@ -1333,7 +1333,7 @@ h1 > span[data-type="footnote"] {
   margin-bottom: 3pt;
   text-align: left;
   text-indent: 0;
-  font-family: SourceSansPro, sans-serif;
+  font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
   font-weight: normal;
 }
 
@@ -1359,13 +1359,13 @@ section[data-type="bibliography"] { page: bibliography }
   
 @page bibliography:left {
   @bottom-left { content: counter(page);
-      font-family: SourceSansPro, sans-serif;
+      font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
  }
 }
 
 @page bibliography:right {
   @bottom-right { content: counter(page);
-      font-family: SourceSansPro, sans-serif;
+      font-family: SourceSansPro, sans-serif, ArialUnicodeMS;
  }
 }
 


### PR DESCRIPTION
Hi @Biladew and @slynchoreilly,

I've made some modifications to the `font-family` declarations in the Technical Theme for PDF to add ArialUnicodeMS as a fallback to ensure more robust Unicode support. Could you please review these changes? If this looks good, please go ahead and deploy. Or if you have suggestions on a better way to implement the `font-family` fallbacks or alternative fonts to use, please feel free to modify.

Thanks,
Sanders
