### PR TITLE
Make top spacing consistent for html/iPad

### DIFF
--- a/html/html.css
+++ b/html/html.css
@@ -555,7 +555,7 @@ div.navbar p a {
 @media screen and (min-width: 480px) and (max-width: 1024px) {
   body {
     width: 100%;
-    padding: 20px;
+    padding: 80px 20px 20px 20px;
   }
 }
 


### PR DESCRIPTION
Hello,

The padding in the HTML body is currently inconsistent for the desktop, tablet and phone media queries, and on those pages with not enough vertical space above (like the TOC page in the default contents) text becomes unreadable on the tablet variant.

The small change introduced in this pull request makes the top spacing consistent.

For reference, this is current behaviour:

Desktop:
![screen shot 2015-03-01 at 22 25 13](https://cloud.githubusercontent.com/assets/56819/6433041/1934fcfe-c065-11e4-91a3-bc3ae7325232.png)

Tablet:
![screen shot 2015-03-01 at 22 25 03](https://cloud.githubusercontent.com/assets/56819/6433044/242a57b2-c065-11e4-8b94-1077f4f973bb.png)

Phone:
![screen shot 2015-03-01 at 22 24 52](https://cloud.githubusercontent.com/assets/56819/6433047/2ab5c1f2-c065-11e4-8c67-30e7482e276e.png)

Thanks,
