### PR TITLE
Fix syntax error in pdf.css

### DIFF
--- a/pdf/pdf.css
+++ b/pdf/pdf.css
@@ -368,7 +368,6 @@ nav[data-type="toc"] li[data-type="part"] {
 }
 
 nav[data-type="toc"] li[data-type="part"] {  margin-top: 24.4pt;}
-}
 
 nav[data-type="toc"] li[data-type="preface"],
 nav[data-type="toc"] li[data-type="foreword"] {


### PR DESCRIPTION
The build engine flags a syntax error here. In fact, this closing brace should not be here.